### PR TITLE
Add tests

### DIFF
--- a/tests/connectors/beatport-www.js
+++ b/tests/connectors/beatport-www.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://www.beatport.com/spinninrecords/tracks/mapzt4k6tw6j/cream-original-mix',
+		'.audio-control_large'
+	);
+
+};

--- a/tests/connectors/bopfm.js
+++ b/tests/connectors/bopfm.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://bop.fm/s/the-weeknd/cant-feel-my-face',
+		'.avatar'
+	);
+
+};

--- a/tests/connectors/edm.js
+++ b/tests/connectors/edm.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://edm.com/tracks/megalodon-virtual-riot-fatal-fist-punch-premiere',
+		'.track-control-holder'
+	);
+
+};

--- a/tests/connectors/farfrommoscow.js
+++ b/tests/connectors/farfrommoscow.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://www.farfrommoscow.com/artists/phooey.html',
+		'#musicbox > :nth-child(3) .player-buttonPlay'
+	);
+
+};

--- a/tests/connectors/getworkdonemusic.js
+++ b/tests/connectors/getworkdonemusic.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://getworkdonemusic.com/',
+		'.sc-remote-link'
+	);
+
+};

--- a/tests/connectors/ghostly.js
+++ b/tests/connectors/ghostly.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://ghostly.com/discovery/play',
+		'.button'
+	);
+
+};

--- a/tests/connectors/indieshuffle.js
+++ b/tests/connectors/indieshuffle.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://www.indieshuffle.com/wennink-dissolve/',
+		'.main-review .figure.commontrack'
+	);
+
+};

--- a/tests/connectors/jamendo.js
+++ b/tests/connectors/jamendo.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://www.jamendo.com/ru/track/1258976/liquid-blue',
+		'.jamactionbutton.listen'
+	);
+
+};

--- a/tests/connectors/moskva-piter-fm.js
+++ b/tests/connectors/moskva-piter-fm.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://www.piter.fm/stations/FM_100.5',
+		'#player-container'
+	);
+
+};

--- a/tests/connectors/musicase.js
+++ b/tests/connectors/musicase.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://www.musicload.de/web/single?id=12518819',
+		'.single-detail .actions'
+	);
+
+};

--- a/tests/connectors/novoeradio1.js
+++ b/tests/connectors/novoeradio1.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://www.novoeradio.by/',
+		'.button-play'
+	);
+
+};

--- a/tests/connectors/radionomy.js
+++ b/tests/connectors/radionomy.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://www.radionomy.com/en/radio/foofightersfanloopradio/index',
+		'.radioPlayBtn'
+	);
+
+};

--- a/tests/connectors/redditmusicplayer.js
+++ b/tests/connectors/redditmusicplayer.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://reddit.musicplayer.io/',
+		'.item.play.button'
+	);
+
+};

--- a/tests/connectors/slashfavorites.js
+++ b/tests/connectors/slashfavorites.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://slashfavorites.com/#jon-kyle',
+		'.refresh'
+	);
+
+};

--- a/tests/connectors/solayo1.js
+++ b/tests/connectors/solayo1.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://solayo.com/media/217602371soundcloud',
+		'.playNow'
+	);
+
+};

--- a/tests/connectors/somafm.js
+++ b/tests/connectors/somafm.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://somafm.com/player/#/all-stations',
+		'#list > :first-child .glyphicon-play'
+	);
+
+};

--- a/tests/connectors/stereodose.js
+++ b/tests/connectors/stereodose.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://www.stereodose.com/user_playlist/25616/molecules-of-light',
+		'.jp-next'
+	);
+
+};

--- a/tests/connectors/tidal1.js
+++ b/tests/connectors/tidal1.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://listen.tidal.com/album/50767183',
+		'.album-header__playbutton'
+	);
+
+};

--- a/tests/connectors/trntblme1.js
+++ b/tests/connectors/trntblme1.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://www.trntbl.me/fuckyeahqualitymusic',
+		'#play-pause'
+	);
+
+};

--- a/tests/connectors/wavome.js
+++ b/tests/connectors/wavome.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://wavo.me/galeksandrp/my-playlist',
+		'.play'
+	);
+
+};

--- a/tests/connectors/xiami.js
+++ b/tests/connectors/xiami.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'http://www.xiami.com/play',
+		'#J_nextBtn'
+	);
+
+};

--- a/tests/connectors/yandexradio.js
+++ b/tests/connectors/yandexradio.js
@@ -1,0 +1,8 @@
+module.exports = function(driver, connector, next) {
+
+	connectorSpec.loadPlayListen(driver, next,
+		'https://radio.yandex.ru/author/plushev',
+		'.player-controls__play'
+	);
+
+};

--- a/tests/connectors/youtube.js
+++ b/tests/connectors/youtube.js
@@ -1,11 +1,13 @@
-module.exports = function(driver, connector, next) {
+module.exports = function (driver, connector, next) {
 
 	var url = 'https://www.youtube.com/watch?v=YqeW9_5kURI';
-	before('should load '+url, function(done) {
+	before('should load ' + url, function (done) {
 		siteSpec.shouldLoad(driver, url, done);
 	});
-	it('should load page: '+url, function(done) { done(); })
-	describe('Loaded website', function() {
+	it('should load page: ' + url, function (done) {
+		done();
+	})
+	describe('Loaded website', function () {
 		connectorSpec.shouldRecogniseATrack(driver);
 	});
 
@@ -27,11 +29,11 @@ module.exports = function(driver, connector, next) {
 	// 			});
 	// 			connectorSpec.shouldRecogniseATrack(driver);
 	// 			connectorSpec.shouldRecogniseAPlaylist(driver, {'comment': playlistVideo.comment });
-    //
+	//
 	// 			after(function() { nextPlaylist(); });
 	// 		});
 	// 	});
-    //
+	//
 	// 	describe('Invalid playlists', function() {
 	// 		async.each([ // From https://github.com/david-sabata/web-scrobbler/pull/755#issue-104480950
 	// 			{ url: 'https://youtube.com/watch?v=EfcY9oFo1YQ', comment: 'incorrect timestamps => invalid playlist' },
@@ -43,12 +45,12 @@ module.exports = function(driver, connector, next) {
 	// 				});
 	// 				connectorSpec.shouldRecogniseATrack(driver);
 	// 				connectorSpec.shouldRecogniseAPlaylist(driver, {'comment': playlistVideo.comment });
-    //
+	//
 	// 				after(function() { nextPlaylist(); });
 	// 			})
 	// 		});
 	// 	});
-    //
+	//
 	// 	after(function() { next(); });
 	// });
 };


### PR DESCRIPTION
- [x] beatport-www
- [x] bopfm
- [x] edm
- [x] farfrommoscow
- [x] getworkdonemusic
- [x] ghostly
- [x] indieshuffle
- [x] jamendo
- [x] moskva-piter-fm
- [x] musicase
- [x] radionomy
- [x] redditmusicplayer
- [x] slashfavorites
- [x] somafm
- [x] stereodose
- [x] wavome
- [x] xiami
- [x] yandexradio

novoeradio & xiami sometimes fails. solayo, tidal, trntblme set warning message `onbeforeunload` that prevent passing to next test.

Some of bugs discovered by this tests fixed in #775, #778.
